### PR TITLE
Add support for Snap configuration

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+. "$SNAP/bin/management-script"
+
+# Supported keys:
+# - stun.host (string)
+#   The hostname or IP address of the STUN server.
+#
+# - stun.port (integer)
+#   The port of the STUN server
+#
+# - turn.host (string)
+#   The hostname or IP address of the TURN server.
+#
+# - turn.port (integer)
+#   The port of the TURN server
+#
+# - turn.static-auth-secret (string)
+#   The static secret used to generate TURN credentials.
+#
+# - twilio.account-sid (string)
+#   A Twilio account SID.
+#
+# - twilio.auth-token (string)
+#   A Twilio account auth token or API key secret.
+#
+# - twilio.key-sid (string)
+#   A Twilio API key SID.
+#
+
+handle_stun_config()
+{
+    camus_stun_host="$(stun_host)"
+    camus_stun_port="$(stun_port)"
+
+    set_stun_host "$camus_stun_host"
+    set_stun_port "$camus_stun_port"
+}
+
+handle_turn_config()
+{
+    camus_turn_host="$(turn_host)"
+    camus_turn_port="$(turn_port)"
+    camus_turn_static_auth_secret="$(turn_static_auth_secret)"
+
+    set_turn_host "$camus_turn_host"
+    set_turn_port "$camus_turn_port"
+    set_turn_static_auth_secret "$camus_turn_static_auth_secret"
+}
+
+handle_twilio_config()
+{
+    camus_twilio_account_sid="$(twilio_account_sid)"
+    camus_twilio_auth_token="$(twilio_auth_token)"
+    camus_twilio_key_sid="$(twilio_key_sid)"
+
+    set_twilio_account_sid "$camus_twilio_account_sid"
+    set_twilio_auth_token "$camus_twilio_auth_token"
+    set_twilio_key_sid "$camus_twilio_key_sid"
+}
+
+handle_turn_config && \
+handle_stun_config && \
+handle_twilio_config && \
+snapctl restart camus

--- a/snap/local/bin/camus-wrapper
+++ b/snap/local/bin/camus-wrapper
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. "$SNAP/bin/management-script"
+
+STUN_HOST="$(stun_host)"
+STUN_PORT="$(stun_port)"
+TURN_HOST="$(turn_host)"
+TURN_PORT="$(turn_port)"
+TURN_STATIC_AUTH_SECRET="$(turn_static_auth_secret)"
+TWILIO_ACCOUNT_SID="$(twilio_account_sid)"
+TWILIO_AUTH_TOKEN="$(twilio_auth_token)"
+TWILIO_KEY_SID="$(twilio_key_sid)"
+export STUN_HOST
+export STUN_PORT
+export TURN_HOST
+export TURN_PORT
+export TURN_STATIC_AUTH_SECRET
+export TWILIO_ACCOUNT_SID
+export TWILIO_AUTH_TOKEN
+export TWILIO_KEY_SID
+
+"$SNAP/bin/camus"

--- a/snap/local/utilities/bin/management-script
+++ b/snap/local/utilities/bin/management-script
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+stun_host()
+{
+	host="$(snapctl get stun.host)"
+	echo "$host"
+}
+
+set_stun_host()
+{
+	snapctl set stun.host="$1"
+}
+
+stun_port()
+{
+	port="$(snapctl get stun.port)"
+	echo "$port"
+}
+
+set_stun_port()
+{
+	snapctl set stun.port="$1"
+}
+
+turn_host()
+{
+	host="$(snapctl get turn.host)"
+	echo "$host"
+}
+
+set_turn_host()
+{
+	snapctl set turn.host="$1"
+}
+
+turn_port()
+{
+	port="$(snapctl get turn.port)"
+	echo "$port"
+}
+
+set_turn_port()
+{
+	snapctl set turn.port="$1"
+}
+
+turn_static_auth_secret()
+{
+	secret="$(snapctl get turn.static-auth-secret)"
+	echo "$secret"
+}
+
+set_turn_static_auth_secret()
+{
+	snapctl set turn.static-auth-secret="$1"
+}
+
+twilio_account_sid()
+{
+	host="$(snapctl get twilio.account-sid)"
+	echo "$host"
+}
+
+set_twilio_account_sid()
+{
+	snapctl set twilio.account-sid="$1"
+}
+
+twilio_auth_token()
+{
+	host="$(snapctl get twilio.auth-token)"
+	echo "$host"
+}
+
+set_twilio_auth_token()
+{
+	snapctl set twilio.auth-token="$1"
+}
+
+twilio_key_sid()
+{
+	host="$(snapctl get twilio.key-sid)"
+	echo "$host"
+}
+
+set_twilio_key_sid()
+{
+	snapctl set twilio.key-sid="$1"
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,14 +12,28 @@ confinement: strict
 
 apps:
   camus:
-    command: bin/camus
+    command: bin/camus-wrapper
     daemon: simple
     restart-condition: always
     plugs:
       - network-bind
       - network
 
+hooks:
+  configure:
+    plugs: [network, network-bind]
+
 parts:
   camus:
     plugin: python
     source: .
+
+  utilities:
+    plugin: dump
+    source: snap/local/utilities/
+
+  bin:
+    plugin: dump
+    source: snap/local/bin/
+    organize:
+      '*': bin/


### PR DESCRIPTION
The Camus server can now take configuration via `snap set`. The following keys are supported:
- stun.host
- stun.port
- turn.host
- turn.port
- turn.static-auth-secret
- twilio.account-sid
- twilio.auth-token
- twilio.key-sid

Example of using a custom STUN server:

```
$ sudo snap set camus stun.host=stun.example.com
$ sudo snap set camus stun.port=3478
```

References:
- https://snapcraft.io/docs/configuration-in-snaps
- https://snapcraft.io/docs/adding-snap-configuration