### PR TITLE
Fixes for build/ test/ deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-language: generic
+language: node
+node_js:
+  - 12
 
 install:
+  - npm version
   - cd $TRAVIS_BUILD_DIR/camus/static && npm install && cd $TRAVIS_BUILD_DIR
 
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 # builder
 FROM python:3.9-alpine as builder
-RUN apk update && \
-    apk add --virtual .build-deps gcc musl-dev postgresql-dev && \
-    pip install psycopg2 --no-cache-dir --no-deps --no-binary :all: && \
-    apk --purge del .build-deps
 RUN apk add make
 ADD . /app
 WORKDIR /app
@@ -15,9 +11,12 @@ FROM python:3.9-alpine as prod
 ENV DATA_DIR="/var/lib/camus"
 ENV DATABASE_URL="sqlite:///$DATA_DIR/camus.db"
 ENV PORT=5000
-RUN apk add postgresql-libs
-COPY --from=builder /usr/local/lib/python3.9/site-packages/psycopg2 /usr/local/lib/python3.9/site-packages/psycopg2
 RUN mkdir -p $DATA_DIR
+RUN apk update && apk add postgresql-libs
 COPY --from=builder /app/dist/camus*.tar.gz /root
-RUN pip install /root/camus*.tar.gz
+RUN apk update && \
+    apk add --virtual .build-deps build-base postgresql-dev && \
+    pip install psycopg2 --no-cache-dir --no-deps --no-binary :all: && \
+    pip install /root/camus*.tar.gz && \
+    apk --purge del .build-deps
 CMD /usr/local/bin/hypercorn "camus:create_app()" --log-file - -b 0.0.0.0:$PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: hypercorn camus --log-file - -b 0.0.0.0:$PORT
+web: hypercorn "camus:create_app()" --log-file - -b 0.0.0.0:$PORT

--- a/bin/camus
+++ b/bin/camus
@@ -1,1 +1,1 @@
-hypercorn camus --log-file - -b 127.0.0.1:5000
+hypercorn "camus:create_app()" --log-file - -b 127.0.0.1:5000

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,5 +5,6 @@ flask-wtf==0.14.3
 hypercorn==0.11.1
 python-slugify==4.0.1
 quart==0.14.1
+SQLAlchemy==1.3.23
 twilio==6.45.4
 werkzeug==1.0.1


### PR DESCRIPTION
- Fix the Procfile for Heroku deployments by calling `camus:create_app()`
- Pin the SQLAlchemy version -- 1.4.0 introduced a [breaking change](https://stackoverflow.com/questions/66647787/attributeerror-cant-set-attribute-when-connecting-to-sqlite-database-with-flas)
- Fix the Travis build -- Travis uses an old version of Node by default, causing errors on `npm install`
- Fix the production Docker image -- wheels were failing to build because the necessary build tools weren't installed