### PR TITLE
Update Snap package for database support

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -28,6 +28,12 @@
 #   A Twilio API key SID.
 #
 
+handle_main_config()
+{
+    set_secret_key "$(secret_key)"
+    set_database_url "$(database_url)"
+}
+
 handle_stun_config()
 {
     camus_stun_host="$(stun_host)"
@@ -59,6 +65,7 @@ handle_twilio_config()
     set_twilio_key_sid "$camus_twilio_key_sid"
 }
 
+handle_main_config && \
 handle_turn_config && \
 handle_stun_config && \
 handle_twilio_config && \

--- a/snap/local/bin/camus-wrapper
+++ b/snap/local/bin/camus-wrapper
@@ -2,6 +2,8 @@
 
 . "$SNAP/bin/management-script"
 
+SECRET_KEY="$(secret_key)"
+DATABASE_URL="$(database_url)"
 STUN_HOST="$(stun_host)"
 STUN_PORT="$(stun_port)"
 TURN_HOST="$(turn_host)"
@@ -10,6 +12,8 @@ TURN_STATIC_AUTH_SECRET="$(turn_static_auth_secret)"
 TWILIO_ACCOUNT_SID="$(twilio_account_sid)"
 TWILIO_AUTH_TOKEN="$(twilio_auth_token)"
 TWILIO_KEY_SID="$(twilio_key_sid)"
+export SECRET_KEY
+export DATABASE_URL
 export STUN_HOST
 export STUN_PORT
 export TURN_HOST

--- a/snap/local/bin/sqlite-client
+++ b/snap/local/bin/sqlite-client
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+. "$SNAP/bin/management-script"
+
+DATABASE_URL="$(database_url)"
+DATABASE_PATH=$(echo $DATABASE_URL | sed -e "s/^sqlite:\/\/\///")
+
+"$SNAP/bin/litecli" "$DATABASE_PATH"

--- a/snap/local/utilities/bin/management-script
+++ b/snap/local/utilities/bin/management-script
@@ -1,5 +1,42 @@
 #!/bin/sh
 
+SQLITE_DIR="$SNAP_DATA/sqlite"
+DEFAULT_DATABASE_URL="sqlite:///$SQLITE_DIR/camus.db"
+
+mkdir -p "$SQLITE_DIR"
+chmod 770 "$SQLITE_DIR"
+
+secret_key()
+{
+    key="$(snapctl get secret-key)"
+    if [ -z "$key" ]; then
+        key="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 64)"
+        set_secret_key $key
+    fi
+    echo "$key"
+}
+
+set_secret_key()
+{
+    snapctl set secret-key="$1"
+}
+
+database_url()
+{
+    url="$(snapctl get database-url)"
+    if [ -z "$url" ]; then
+        url="$DEFAULT_DATABASE_URL"
+        set_database_url $url
+    fi
+
+    echo "$url"
+}
+
+set_database_url()
+{
+    snapctl set database-url="$1"
+}
+
 stun_host()
 {
 	host="$(snapctl get stun.host)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,15 @@ description: |
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: armhf
+  - build-on: ppc64el
+  - build-on: s390x
+
 apps:
+  # Camus server daemon
   camus:
     command: bin/camus-wrapper
     daemon: simple
@@ -18,6 +26,10 @@ apps:
     plugs:
       - network-bind
       - network
+
+  # SQLite client
+  sqlite-client:
+    command: bin/sqlite-client
 
 hooks:
   configure:
@@ -27,6 +39,8 @@ parts:
   camus:
     plugin: python
     source: .
+    python-packages:
+      - litecli
 
   utilities:
     plugin: dump


### PR DESCRIPTION
Add support for database:
- Add configuration option to set the `DATABASE_URL` (use a local SQLite database by default)
- Add [litecli](https://litecli.com/) and the `sqlite-client` command to allow database administration for SQLite